### PR TITLE
LPD-17488 Fix counters before upgrade process

### DIFF
--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/osgi/commands/PortalAddressOSGiCommands.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/osgi/commands/PortalAddressOSGiCommands.java
@@ -6,6 +6,7 @@
 package com.liferay.address.internal.osgi.commands;
 
 import com.liferay.address.internal.util.CompanyCountriesUtil;
+import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.osgi.util.osgi.commands.OSGiCommands;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -51,7 +52,7 @@ public class PortalAddressOSGiCommands implements OSGiCommands {
 		try (Connection connection = DataAccess.getConnection()) {
 			CompanyCountriesUtil.populateCompanyCountries(
 				_companyLocalService.getCompany(companyId),
-				_countryLocalService, connection);
+				_counterLocalService, _countryLocalService, connection);
 		}
 	}
 
@@ -82,8 +83,8 @@ public class PortalAddressOSGiCommands implements OSGiCommands {
 
 				if (!countryNames.contains(name)) {
 					CompanyCountriesUtil.addCountry(
-						company, countryJSONObject, _countryLocalService,
-						connection);
+						company, _counterLocalService, countryJSONObject,
+						_countryLocalService, connection);
 
 					continue;
 				}
@@ -100,7 +101,8 @@ public class PortalAddressOSGiCommands implements OSGiCommands {
 					country.getPosition(), country.isShippingAllowed(),
 					country.isSubjectToVAT());
 
-				CompanyCountriesUtil.processCountryRegions(country, connection);
+				CompanyCountriesUtil.processCountryRegions(
+					country, connection, _counterLocalService);
 			}
 			catch (Exception exception) {
 				_log.error(exception);
@@ -113,6 +115,9 @@ public class PortalAddressOSGiCommands implements OSGiCommands {
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private CounterLocalService _counterLocalService;
 
 	@Reference
 	private CountryLocalService _countryLocalService;

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/portal/instance/lifecycle/PortalInstanceLifecycleListenerImpl.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/portal/instance/lifecycle/PortalInstanceLifecycleListenerImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.address.internal.portal.instance.lifecycle;
 
 import com.liferay.address.internal.util.CompanyCountriesUtil;
+import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
@@ -33,10 +34,13 @@ public class PortalInstanceLifecycleListenerImpl
 	@Override
 	public void portalInstanceRegistered(Company company) throws Exception {
 		CompanyCountriesUtil.populateCompanyCountries(
-			company, _countryLocalService,
+			company, _counterLocalService, _countryLocalService,
 			_currentConnection.getConnection(
 				InfrastructureUtil.getDataSource()));
 	}
+
+	@Reference
+	private CounterLocalService _counterLocalService;
 
 	@Reference
 	private CountryLocalService _countryLocalService;

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/upgrade/registry/AddressUpgradeStepRegistrator.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/upgrade/registry/AddressUpgradeStepRegistrator.java
@@ -7,6 +7,7 @@ package com.liferay.address.internal.upgrade.registry;
 
 import com.liferay.address.internal.upgrade.v1_0_0.CountryUpgradeProcess;
 import com.liferay.address.internal.upgrade.v1_0_1.CountryRegionUpgradeProcess;
+import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.CountryLocalService;
@@ -32,19 +33,22 @@ public class AddressUpgradeStepRegistrator implements UpgradeStepRegistrator {
 		registry.register(
 			"1.0.0", "1.0.1",
 			new CountryRegionUpgradeProcess(
-				_companyLocalService, _countryLocalService,
-				_regionLocalService));
+				_companyLocalService, _counterLocalService,
+				_countryLocalService, _regionLocalService));
 
 		registry.register(
 			"1.0.1", "1.0.2",
 			new com.liferay.address.internal.upgrade.v1_0_2.
 				CountryUpgradeProcess(
-					_companyLocalService, _countryLocalService, _jsonFactory,
-					_regionLocalService));
+					_companyLocalService, _counterLocalService,
+					_countryLocalService, _jsonFactory, _regionLocalService));
 	}
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private CounterLocalService _counterLocalService;
 
 	@Reference
 	private CountryLocalService _countryLocalService;

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/upgrade/v1_0_1/CountryRegionUpgradeProcess.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/upgrade/v1_0_1/CountryRegionUpgradeProcess.java
@@ -6,6 +6,7 @@
 package com.liferay.address.internal.upgrade.v1_0_1;
 
 import com.liferay.address.internal.util.CompanyCountriesUtil;
+import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -38,18 +39,22 @@ public class CountryRegionUpgradeProcess extends UpgradeProcess {
 
 	public CountryRegionUpgradeProcess(
 		CompanyLocalService companyLocalService,
+		CounterLocalService counterLocalService,
 		CountryLocalService countryLocalService,
 		RegionLocalService regionLocalService) {
 
 		_companyLocalService = companyLocalService;
+		_counterLocalService = counterLocalService;
 		_countryLocalService = countryLocalService;
 		_regionLocalService = regionLocalService;
 	}
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		CompanyCountriesUtil.updateRegionCounter(getConnection());
-		CompanyCountriesUtil.updateRegionLocalizationCounter(getConnection());
+		CompanyCountriesUtil.updateRegionCounter(
+			getConnection(), _counterLocalService);
+		CompanyCountriesUtil.updateRegionLocalizationCounter(
+			getConnection(), _counterLocalService);
 
 		_updateRegion("FR", "75C", "75", "Paris");
 		_updateRegion("MX", "CMX", "DIF", "Ciudad de México");
@@ -214,17 +219,23 @@ public class CountryRegionUpgradeProcess extends UpgradeProcess {
 		}
 		else {
 			String oldRegionCode = region.getRegionCode();
+			String oldRegionName = region.getName();
+
+			if (Objects.equals(oldRegionCode, newRegionCode) &&
+				Objects.equals(
+					oldRegionName, regionJSONObject.getString("name"))) {
+
+				return;
+			}
 
 			region.setName(regionJSONObject.getString("name"));
 			region.setRegionCode(newRegionCode);
 
 			region = _regionLocalService.updateRegion(region);
 
-			if (!Objects.equals(oldRegionCode, newRegionCode)) {
-				_updateData(
-					country.getA2(), region.getRegionCode(), oldRegionCode,
-					"CIWarehouse");
-			}
+			_updateData(
+				country.getA2(), region.getRegionCode(), oldRegionCode,
+				"CIWarehouse");
 		}
 
 		JSONObject localizationsJSONObject = regionJSONObject.getJSONObject(
@@ -294,6 +305,7 @@ public class CountryRegionUpgradeProcess extends UpgradeProcess {
 		CountryRegionUpgradeProcess.class);
 
 	private final CompanyLocalService _companyLocalService;
+	private final CounterLocalService _counterLocalService;
 	private final CountryLocalService _countryLocalService;
 	private final RegionLocalService _regionLocalService;
 

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/upgrade/v1_0_1/CountryRegionUpgradeProcess.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/upgrade/v1_0_1/CountryRegionUpgradeProcess.java
@@ -48,6 +48,9 @@ public class CountryRegionUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
+		CompanyCountriesUtil.updateRegionCounter(getConnection());
+		CompanyCountriesUtil.updateRegionLocalizationCounter(getConnection());
+
 		_updateRegion("FR", "75C", "75", "Paris");
 		_updateRegion("MX", "CMX", "DIF", "Ciudad de México");
 		_updateRegion("NL", "BO", "BQ1", "Bonaire");

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/upgrade/v1_0_2/CountryUpgradeProcess.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/upgrade/v1_0_2/CountryUpgradeProcess.java
@@ -6,6 +6,7 @@
 package com.liferay.address.internal.upgrade.v1_0_2;
 
 import com.liferay.address.internal.util.CompanyCountriesUtil;
+import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
@@ -30,10 +31,12 @@ public class CountryUpgradeProcess extends UpgradeProcess {
 
 	public CountryUpgradeProcess(
 		CompanyLocalService companyLocalService,
+		CounterLocalService counterLocalService,
 		CountryLocalService countryLocalService, JSONFactory jsonFactory,
 		RegionLocalService regionLocalService) {
 
 		_companyLocalService = companyLocalService;
+		_counterLocalService = counterLocalService;
 		_countryLocalService = countryLocalService;
 		_jsonFactory = jsonFactory;
 		_regionLocalService = regionLocalService;
@@ -97,8 +100,9 @@ public class CountryUpgradeProcess extends UpgradeProcess {
 		}
 
 		CompanyCountriesUtil.addCountry(
-			company, _jsonFactory.createJSONObject(countryMap),
-			_countryLocalService, connection);
+			company, _counterLocalService,
+			_jsonFactory.createJSONObject(countryMap), _countryLocalService,
+			connection);
 
 		Country chinaCountry = _countryLocalService.fetchCountryByA2(
 			company.getCompanyId(), "CN");
@@ -192,6 +196,7 @@ public class CountryUpgradeProcess extends UpgradeProcess {
 		CountryUpgradeProcess.class);
 
 	private final CompanyLocalService _companyLocalService;
+	private final CounterLocalService _counterLocalService;
 	private final CountryLocalService _countryLocalService;
 	private final JSONFactory _jsonFactory;
 	private final RegionLocalService _regionLocalService;

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/util/CompanyCountriesUtil.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/util/CompanyCountriesUtil.java
@@ -239,65 +239,18 @@ public class CompanyCountriesUtil {
 			Connection connection, CounterLocalService counterLocalService)
 		throws Exception {
 
-		try (Statement statement = connection.createStatement();
-			ResultSet resultSet1 = statement.executeQuery(
-				StringBundler.concat(
-					"select currentId from Counter where name = '",
-					Region.class.getName(), "'"))) {
-
-			long counter = 0;
-
-			if (resultSet1.next()) {
-				counter = resultSet1.getLong("currentId");
-			}
-
-			try (ResultSet resultSet2 = statement.executeQuery(
-					"select max(regionId) from Region")) {
-
-				if (resultSet2.next()) {
-					long increment = Math.max(
-						0, resultSet2.getLong(1) - counter);
-
-					if (increment > 0) {
-						counterLocalService.increment(
-							Region.class.getName(), (int)increment);
-					}
-				}
-			}
-		}
+		_updateCounter(
+			connection, counterLocalService, Region.class.getName(), "Region",
+			"regionId");
 	}
 
 	public static void updateRegionLocalizationCounter(
 			Connection connection, CounterLocalService counterLocalService)
 		throws Exception {
 
-		try (Statement statement = connection.createStatement();
-			ResultSet resultSet1 = statement.executeQuery(
-				StringBundler.concat(
-					"select currentId from Counter where name = '",
-					RegionLocalization.class.getName(), "'"))) {
-
-			long counter = 0;
-
-			if (resultSet1.next()) {
-				counter = resultSet1.getLong("currentId");
-			}
-
-			try (ResultSet resultSet2 = statement.executeQuery(
-					"select max(regionLocalizationId) from " +
-						"RegionLocalization")) {
-
-				if (resultSet2.next()) {
-					long increment = Math.max(
-						0, resultSet2.getLong(1) - counter);
-
-					if (increment > 0) {
-						counterLocalService.increment(
-							RegionLocalization.class.getName(), (int)increment);
-					}
-				}
-			}
-		}
+		_updateCounter(
+			connection, counterLocalService, RegionLocalization.class.getName(),
+			"RegionLocalization", "regionLocalizationId");
 	}
 
 	private static void _addRegionBatch(
@@ -332,6 +285,39 @@ public class CompanyCountriesUtil {
 		preparedStatement.setString(5, title);
 
 		preparedStatement.addBatch();
+	}
+
+	private static void _updateCounter(
+			Connection connection, CounterLocalService counterLocalService,
+			String className, String tableName, String primaryKey)
+		throws Exception {
+
+		try (Statement statement = connection.createStatement();
+			ResultSet resultSet1 = statement.executeQuery(
+				StringBundler.concat(
+					"select currentId from Counter where name = '", className,
+					"'"))) {
+
+			long counter = 0;
+
+			if (resultSet1.next()) {
+				counter = resultSet1.getLong("currentId");
+			}
+
+			try (ResultSet resultSet2 = statement.executeQuery(
+					"select max(" + primaryKey + ") from " + tableName)) {
+
+				if (resultSet2.next()) {
+					long increment = Math.max(
+						0, resultSet2.getLong(1) - counter);
+
+					if (increment > 0) {
+						counterLocalService.increment(
+							RegionLocalization.class.getName(), (int)increment);
+					}
+				}
+			}
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/util/CompanyCountriesUtil.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/util/CompanyCountriesUtil.java
@@ -240,8 +240,8 @@ public class CompanyCountriesUtil {
 		throws Exception {
 
 		_updateCounter(
-			connection, counterLocalService, Region.class.getName(), "Region",
-			"regionId");
+			Region.class.getName(), connection, counterLocalService, "regionId",
+			"Region");
 	}
 
 	public static void updateRegionLocalizationCounter(
@@ -249,8 +249,8 @@ public class CompanyCountriesUtil {
 		throws Exception {
 
 		_updateCounter(
-			connection, counterLocalService, RegionLocalization.class.getName(),
-			"RegionLocalization", "regionLocalizationId");
+			RegionLocalization.class.getName(), connection, counterLocalService,
+			"regionLocalizationId", "RegionLocalization");
 	}
 
 	private static void _addRegionBatch(
@@ -288,32 +288,38 @@ public class CompanyCountriesUtil {
 	}
 
 	private static void _updateCounter(
-			Connection connection, CounterLocalService counterLocalService,
-			String className, String tableName, String primaryKey)
+			String className, Connection connection,
+			CounterLocalService counterLocalService, String primaryKey,
+			String tableName)
 		throws Exception {
 
-		try (Statement statement = connection.createStatement();
-			ResultSet resultSet1 = statement.executeQuery(
-				StringBundler.concat(
-					"select currentId from Counter where name = '", className,
-					"'"))) {
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select currentId from Counter where name = ?")) {
 
-			long counter = 0;
+			preparedStatement.setString(1, className);
 
-			if (resultSet1.next()) {
-				counter = resultSet1.getLong("currentId");
+			long currentId;
+
+			try (ResultSet resultSet1 = preparedStatement.executeQuery()) {
+				if (!resultSet1.next()) {
+					return;
+				}
+
+				currentId = resultSet1.getLong("currentId");
 			}
 
-			try (ResultSet resultSet2 = statement.executeQuery(
-					"select max(" + primaryKey + ") from " + tableName)) {
+			try (Statement statement = connection.createStatement();
+				ResultSet resultSet2 = statement.executeQuery(
+					StringBundler.concat(
+						"select max(", primaryKey, ") from ", tableName))) {
 
 				if (resultSet2.next()) {
 					long increment = Math.max(
-						0, resultSet2.getLong(1) - counter);
+						0, resultSet2.getLong(1) - currentId);
 
 					if (increment > 0) {
 						counterLocalService.increment(
-							RegionLocalization.class.getName(), (int)increment);
+							tableName, (int)increment);
 					}
 				}
 			}

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/util/CompanyCountriesUtil.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/util/CompanyCountriesUtil.java
@@ -206,7 +206,7 @@ public class CompanyCountriesUtil {
 
 						_addRegionLocalizationBatch(
 							regionLocalizationPreparedStatement,
-							country.getCountryId(),
+							country.getCompanyId(),
 							LanguageUtil.getLanguageId(locale), regionId,
 							regionJSONObject.getString("name"));
 					}
@@ -215,7 +215,7 @@ public class CompanyCountriesUtil {
 					for (String key : localizationsJSONObject.keySet()) {
 						_addRegionLocalizationBatch(
 							regionLocalizationPreparedStatement,
-							country.getCountryId(), key, regionId,
+							country.getCompanyId(), key, regionId,
 							localizationsJSONObject.getString(key));
 					}
 				}
@@ -278,7 +278,7 @@ public class CompanyCountriesUtil {
 	}
 
 	private static void _addRegionLocalizationBatch(
-			PreparedStatement preparedStatement, long countryId,
+			PreparedStatement preparedStatement, long companyId,
 			String languageId, long regionId, String title)
 		throws SQLException {
 
@@ -286,7 +286,7 @@ public class CompanyCountriesUtil {
 			1,
 			CounterLocalServiceUtil.increment(
 				RegionLocalization.class.getName()));
-		preparedStatement.setLong(2, countryId);
+		preparedStatement.setLong(2, companyId);
 		preparedStatement.setLong(3, regionId);
 		preparedStatement.setString(4, languageId);
 		preparedStatement.setString(5, title);

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/util/CompanyCountriesUtil.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/util/CompanyCountriesUtil.java
@@ -5,7 +5,7 @@
 
 package com.liferay.address.internal.util;
 
-import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
+import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -44,7 +44,8 @@ import java.util.Map;
 public class CompanyCountriesUtil {
 
 	public static void addCountry(
-			Company company, JSONObject countryJSONObject,
+			Company company, CounterLocalService counterLocalService,
+			JSONObject countryJSONObject,
 			CountryLocalService countryLocalService, Connection connection)
 		throws Exception {
 
@@ -78,7 +79,7 @@ public class CompanyCountriesUtil {
 
 			countryLocalService.updateCountryLocalizations(country, titleMap);
 
-			processCountryRegions(country, connection);
+			processCountryRegions(country, connection, counterLocalService);
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);
@@ -99,12 +100,12 @@ public class CompanyCountriesUtil {
 	}
 
 	public static void populateCompanyCountries(
-			Company company, CountryLocalService countryLocalService,
-			Connection connection)
+			Company company, CounterLocalService counterLocalService,
+			CountryLocalService countryLocalService, Connection connection)
 		throws Exception {
 
-		updateRegionCounter(connection);
-		updateRegionLocalizationCounter(connection);
+		updateRegionCounter(connection, counterLocalService);
+		updateRegionLocalizationCounter(connection, counterLocalService);
 
 		int count = countryLocalService.getCompanyCountriesCount(
 			company.getCompanyId());
@@ -134,8 +135,8 @@ public class CompanyCountriesUtil {
 
 			try {
 				addCountry(
-					company, countryJSONObject, countryLocalService,
-					connection);
+					company, counterLocalService, countryJSONObject,
+					countryLocalService, connection);
 			}
 			catch (Exception exception) {
 				_log.error(exception);
@@ -144,7 +145,8 @@ public class CompanyCountriesUtil {
 	}
 
 	public static void processCountryRegions(
-			Country country, Connection connection)
+			Country country, Connection connection,
+			CounterLocalService counterLocalService)
 		throws Exception {
 
 		String a2 = country.getA2();
@@ -187,7 +189,7 @@ public class CompanyCountriesUtil {
 			for (int i = 0; i < regionsJSONArray.length(); i++) {
 				JSONObject regionJSONObject = regionsJSONArray.getJSONObject(i);
 
-				long regionId = CounterLocalServiceUtil.increment(
+				long regionId = counterLocalService.increment(
 					Region.class.getName());
 
 				_addRegionBatch(
@@ -208,6 +210,8 @@ public class CompanyCountriesUtil {
 							regionLocalizationPreparedStatement,
 							country.getCompanyId(),
 							LanguageUtil.getLanguageId(locale), regionId,
+							counterLocalService.increment(
+								RegionLocalization.class.getName()),
 							regionJSONObject.getString("name"));
 					}
 				}
@@ -216,6 +220,8 @@ public class CompanyCountriesUtil {
 						_addRegionLocalizationBatch(
 							regionLocalizationPreparedStatement,
 							country.getCompanyId(), key, regionId,
+							counterLocalService.increment(
+								RegionLocalization.class.getName()),
 							localizationsJSONObject.getString(key));
 					}
 				}
@@ -229,31 +235,67 @@ public class CompanyCountriesUtil {
 		}
 	}
 
-	public static void updateRegionCounter(Connection connection)
+	public static void updateRegionCounter(
+			Connection connection, CounterLocalService counterLocalService)
 		throws Exception {
 
 		try (Statement statement = connection.createStatement();
-			ResultSet resultSet = statement.executeQuery(
-				"select max(regionId) from Region")) {
+			ResultSet resultSet1 = statement.executeQuery(
+				StringBundler.concat(
+					"select currentId from Counter where name = '",
+					Region.class.getName(), "'"))) {
 
-			if (resultSet.next()) {
-				CounterLocalServiceUtil.increment(
-					Region.class.getName(), (int)resultSet.getLong(1));
+			long counter = 0;
+
+			if (resultSet1.next()) {
+				counter = resultSet1.getLong("currentId");
+			}
+
+			try (ResultSet resultSet2 = statement.executeQuery(
+					"select max(regionId) from Region")) {
+
+				if (resultSet2.next()) {
+					long increment = Math.max(
+						0, resultSet2.getLong(1) - counter);
+
+					if (increment > 0) {
+						counterLocalService.increment(
+							Region.class.getName(), (int)increment);
+					}
+				}
 			}
 		}
 	}
 
-	public static void updateRegionLocalizationCounter(Connection connection)
+	public static void updateRegionLocalizationCounter(
+			Connection connection, CounterLocalService counterLocalService)
 		throws Exception {
 
 		try (Statement statement = connection.createStatement();
-			ResultSet resultSet = statement.executeQuery(
-				"select max(regionLocalizationId) from RegionLocalization")) {
+			ResultSet resultSet1 = statement.executeQuery(
+				StringBundler.concat(
+					"select currentId from Counter where name = '",
+					RegionLocalization.class.getName(), "'"))) {
 
-			if (resultSet.next()) {
-				CounterLocalServiceUtil.increment(
-					RegionLocalization.class.getName(),
-					(int)resultSet.getLong(1));
+			long counter = 0;
+
+			if (resultSet1.next()) {
+				counter = resultSet1.getLong("currentId");
+			}
+
+			try (ResultSet resultSet2 = statement.executeQuery(
+					"select max(regionLocalizationId) from " +
+						"RegionLocalization")) {
+
+				if (resultSet2.next()) {
+					long increment = Math.max(
+						0, resultSet2.getLong(1) - counter);
+
+					if (increment > 0) {
+						counterLocalService.increment(
+							RegionLocalization.class.getName(), (int)increment);
+					}
+				}
 			}
 		}
 	}
@@ -279,13 +321,11 @@ public class CompanyCountriesUtil {
 
 	private static void _addRegionLocalizationBatch(
 			PreparedStatement preparedStatement, long companyId,
-			String languageId, long regionId, String title)
+			String languageId, long regionId, long regionLocalizationId,
+			String title)
 		throws SQLException {
 
-		preparedStatement.setLong(
-			1,
-			CounterLocalServiceUtil.increment(
-				RegionLocalization.class.getName()));
+		preparedStatement.setLong(1, regionLocalizationId);
 		preparedStatement.setLong(2, companyId);
 		preparedStatement.setLong(3, regionId);
 		preparedStatement.setString(4, languageId);

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/util/CompanyCountriesUtil.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/util/CompanyCountriesUtil.java
@@ -30,7 +30,9 @@ import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -100,6 +102,9 @@ public class CompanyCountriesUtil {
 			Company company, CountryLocalService countryLocalService,
 			Connection connection)
 		throws Exception {
+
+		updateRegionCounter(connection);
+		updateRegionLocalizationCounter(connection);
 
 		int count = countryLocalService.getCompanyCountriesCount(
 			company.getCompanyId());
@@ -221,6 +226,35 @@ public class CompanyCountriesUtil {
 		}
 		catch (Exception exception) {
 			_log.error(exception);
+		}
+	}
+
+	public static void updateRegionCounter(Connection connection)
+		throws Exception {
+
+		try (Statement statement = connection.createStatement();
+			ResultSet resultSet = statement.executeQuery(
+				"select max(regionId) from Region")) {
+
+			if (resultSet.next()) {
+				CounterLocalServiceUtil.increment(
+					Region.class.getName(), (int)resultSet.getLong(1));
+			}
+		}
+	}
+
+	public static void updateRegionLocalizationCounter(Connection connection)
+		throws Exception {
+
+		try (Statement statement = connection.createStatement();
+			ResultSet resultSet = statement.executeQuery(
+				"select max(regionLocalizationId) from RegionLocalization")) {
+
+			if (resultSet.next()) {
+				CounterLocalServiceUtil.increment(
+					RegionLocalization.class.getName(),
+					(int)resultSet.getLong(1));
+			}
 		}
 	}
 

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/util/CompanyCountriesUtil.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/util/CompanyCountriesUtil.java
@@ -104,9 +104,6 @@ public class CompanyCountriesUtil {
 			CountryLocalService countryLocalService, Connection connection)
 		throws Exception {
 
-		updateRegionCounter(connection, counterLocalService);
-		updateRegionLocalizationCounter(connection, counterLocalService);
-
 		int count = countryLocalService.getCompanyCountriesCount(
 			company.getCompanyId());
 
@@ -121,6 +118,9 @@ public class CompanyCountriesUtil {
 
 			return;
 		}
+
+		updateRegionCounter(connection, counterLocalService);
+		updateRegionLocalizationCounter(connection, counterLocalService);
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(

--- a/modules/apps/address/address-test/build.gradle
+++ b/modules/apps/address/address-test/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
@@ -82,7 +82,6 @@ public class CountryRegionUpgradeProcessTest {
 			});
 
 		_verifyCounters();
-		_verifyRegionLocalizationCompanyId();
 	}
 
 	private void _runUpgrade() throws Exception {
@@ -109,28 +108,6 @@ public class CountryRegionUpgradeProcessTest {
 				Region.class.getName()));
 	}
 
-	private void _verifyRegionLocalizationCompanyId() {
-		int count = _companyLocalService.dslQueryCount(
-			DSLQueryFactoryUtil.select(
-				DSLFunctionFactoryUtil.count(
-					RegionLocalizationTable.INSTANCE.companyId
-				).as(
-					"COUNT_VALUE"
-				)
-			).from(
-				RegionLocalizationTable.INSTANCE
-			).where(
-				RegionLocalizationTable.INSTANCE.companyId.notIn(
-					DSLQueryFactoryUtil.select(
-						CompanyTable.INSTANCE.companyId
-					).from(
-						CompanyTable.INSTANCE
-					))
-			));
-
-		Assert.assertEquals(0, count);
-	}
-
 	private static final String _CLASS_NAME =
 		"com.liferay.address.internal.upgrade.v1_0_1." +
 			"CountryRegionUpgradeProcess";
@@ -148,9 +125,6 @@ public class CountryRegionUpgradeProcessTest {
 
 	@Inject
 	private CountryLocalService _countryLocalService;
-
-	@Inject
-	private MultiVMPool _multiVMPool;
 
 	@Inject
 	private RegionLocalService _regionLocalService;

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
@@ -28,6 +28,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.portal.util.PortalInstances;
 
 import java.util.List;
 
@@ -52,28 +53,34 @@ public class CountryRegionUpgradeProcessTest {
 
 	@Test
 	public void testUpgradeProcessRegionCreation() throws Exception {
+		Country country = _countryLocalService.fetchCountryByA2(
+			PortalInstances.getDefaultCompanyId(), "US");
+
+		int regionsCount = _regionLocalService.getRegionsCount(
+			country.getCountryId());
+
 		CompanyTestUtil.addCompany();
 
 		_companyLocalService.forEachCompanyId(
 			companyId -> {
-				Country country = _countryLocalService.fetchCountryByA2(
+				Country companyCountry = _countryLocalService.fetchCountryByA2(
 					companyId, "US");
 
 				_regionLocalService.deleteCountryRegions(
-					country.getCountryId());
+					companyCountry.getCountryId());
 			});
 
 		_runUpgrade();
 
 		_companyLocalService.forEachCompanyId(
 			companyId -> {
-				Country country = _countryLocalService.fetchCountryByA2(
+				Country companyCountry = _countryLocalService.fetchCountryByA2(
 					companyId, "US");
 
 				Assert.assertEquals(
-					57,
+					regionsCount,
 					_regionLocalService.getRegionsCount(
-						country.getCountryId()));
+						companyCountry.getCountryId()));
 			});
 
 		_verifyCounters();

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
@@ -1,0 +1,174 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.address.internal.upgrade.v1_0_1.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyTable;
+import com.liferay.portal.kernel.model.Country;
+import com.liferay.portal.kernel.model.Region;
+import com.liferay.portal.kernel.model.RegionLocalizationTable;
+import com.liferay.portal.kernel.model.RegionTable;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.CountryLocalService;
+import com.liferay.portal.kernel.service.RegionLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Stefano Motta
+ */
+@RunWith(Arquillian.class)
+public class CountryRegionUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testUpgradeProcessRegionCreation() throws Exception {
+		_companyLocalService.forEachCompany(
+			company -> {
+				Country country = _countryLocalService.fetchCountryByA2(
+					company.getCompanyId(), "US");
+
+				if (country == null) {
+					return;
+				}
+
+				_regionLocalService.deleteCountryRegions(
+					country.getCountryId());
+			});
+
+		_runUpgrade();
+
+		_companyLocalService.forEachCompany(
+			company -> {
+				Country country = _countryLocalService.fetchCountryByA2(
+					company.getCompanyId(), "US");
+
+				if (country == null) {
+					return;
+				}
+
+				Assert.assertEquals(
+					57,
+					_regionLocalService.getRegionsCount(
+						country.getCountryId()));
+			});
+
+		Company company = CompanyTestUtil.addCompany();
+
+		Country country = _countryLocalService.getCountryByA2(
+			company.getCompanyId(), "US");
+
+		Assert.assertEquals(
+			57, _regionLocalService.getRegionsCount(country.getCountryId()));
+
+		_verifyCounters();
+		_verifyRegionLocalizationCompanyId();
+	}
+
+	private void _runUpgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_multiVMPool.clear();
+		}
+	}
+
+	private void _verifyCounters() {
+		List<Long> results = _regionLocalService.dslQuery(
+			DSLQueryFactoryUtil.select(
+				DSLFunctionFactoryUtil.max(
+					RegionTable.INSTANCE.regionId
+				).as(
+					"MAX_VALUE"
+				)
+			).from(
+				RegionTable.INSTANCE
+			));
+
+		Assert.assertTrue(
+			results.get(0) <= _counterLocalService.getCurrentId(
+				Region.class.getName()));
+	}
+
+	private void _verifyRegionLocalizationCompanyId() {
+		int count = _companyLocalService.dslQueryCount(
+			DSLQueryFactoryUtil.select(
+				DSLFunctionFactoryUtil.count(
+					RegionLocalizationTable.INSTANCE.companyId
+				).as(
+					"COUNT_VALUE"
+				)
+			).from(
+				RegionLocalizationTable.INSTANCE
+			).where(
+				RegionLocalizationTable.INSTANCE.companyId.notIn(
+					DSLQueryFactoryUtil.select(
+						CompanyTable.INSTANCE.companyId
+					).from(
+						CompanyTable.INSTANCE
+					))
+			));
+
+		Assert.assertEquals(0, count);
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.address.internal.upgrade.v1_0_1." +
+			"CountryRegionUpgradeProcess";
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.address.internal.upgrade.registry.AddressUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private CounterLocalService _counterLocalService;
+
+	@Inject
+	private CountryLocalService _countryLocalService;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	@Inject
+	private RegionLocalService _regionLocalService;
+
+}

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.service.RegionLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.test.log.LogCapture;
-import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -88,16 +86,10 @@ public class CountryRegionUpgradeProcessTest {
 	}
 
 	private void _runUpgrade() throws Exception {
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				_CLASS_NAME, LoggerTestUtil.OFF)) {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
 
-			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
-				_upgradeStepRegistrator, _CLASS_NAME);
-
-			upgradeProcess.upgrade();
-
-			_multiVMPool.clear();
-		}
+		upgradeProcess.upgrade();
 	}
 
 	private void _verifyCounters() {

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.Region;
 import com.liferay.portal.kernel.model.RegionTable;
@@ -16,6 +17,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.CountryLocalService;
 import com.liferay.portal.kernel.service.RegionLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.test.rule.Inject;
@@ -27,7 +29,9 @@ import com.liferay.portal.util.PortalInstances;
 
 import java.util.List;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,6 +40,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Stefano Motta
  */
+@DataGuard(scope = DataGuard.Scope.NONE)
 @RunWith(Arquillian.class)
 public class CountryRegionUpgradeProcessTest {
 
@@ -46,36 +51,44 @@ public class CountryRegionUpgradeProcessTest {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
-	@Test
-	public void testUpgradeProcessRegionCreation() throws Exception {
+	@BeforeClass
+	public static void setUpClass() throws Exception {
 		Country country = _countryLocalService.fetchCountryByA2(
 			PortalInstances.getDefaultCompanyId(), "US");
 
-		int regionsCount = _regionLocalService.getRegionsCount(
+		_regionsCount = _regionLocalService.getRegionsCount(
 			country.getCountryId());
 
-		CompanyTestUtil.addCompany();
+		_company = CompanyTestUtil.addCompany();
+	}
 
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_companyLocalService.deleteCompany(_company);
+	}
+
+	@Test
+	public void testUpgradeProcessRegionCreation() throws Exception {
 		_companyLocalService.forEachCompanyId(
 			companyId -> {
-				Country companyCountry = _countryLocalService.fetchCountryByA2(
+				Country country = _countryLocalService.fetchCountryByA2(
 					companyId, "US");
 
 				_regionLocalService.deleteCountryRegions(
-					companyCountry.getCountryId());
+					country.getCountryId());
 			});
 
 		_runUpgrade();
 
 		_companyLocalService.forEachCompanyId(
 			companyId -> {
-				Country companyCountry = _countryLocalService.fetchCountryByA2(
+				Country country = _countryLocalService.fetchCountryByA2(
 					companyId, "US");
 
 				Assert.assertEquals(
-					regionsCount,
+					_regionsCount,
 					_regionLocalService.getRegionsCount(
-						companyCountry.getCountryId()));
+						country.getCountryId()));
 			});
 
 		_verifyCounter();
@@ -109,21 +122,25 @@ public class CountryRegionUpgradeProcessTest {
 		"com.liferay.address.internal.upgrade.v1_0_1." +
 			"CountryRegionUpgradeProcess";
 
+	private static Company _company;
+
+	@Inject
+	private static CompanyLocalService _companyLocalService;
+
+	@Inject
+	private static CounterLocalService _counterLocalService;
+
+	@Inject
+	private static CountryLocalService _countryLocalService;
+
+	@Inject
+	private static RegionLocalService _regionLocalService;
+
+	private static int _regionsCount;
+
 	@Inject(
 		filter = "(&(component.name=com.liferay.address.internal.upgrade.registry.AddressUpgradeStepRegistrator))"
 	)
 	private static UpgradeStepRegistrator _upgradeStepRegistrator;
-
-	@Inject
-	private CompanyLocalService _companyLocalService;
-
-	@Inject
-	private CounterLocalService _counterLocalService;
-
-	@Inject
-	private CountryLocalService _countryLocalService;
-
-	@Inject
-	private RegionLocalService _regionLocalService;
 
 }

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
@@ -59,10 +59,6 @@ public class CountryRegionUpgradeProcessTest {
 				Country country = _countryLocalService.fetchCountryByA2(
 					companyId, "US");
 
-				if (country == null) {
-					return;
-				}
-
 				_regionLocalService.deleteCountryRegions(
 					country.getCountryId());
 			});
@@ -73,10 +69,6 @@ public class CountryRegionUpgradeProcessTest {
 			companyId -> {
 				Country country = _countryLocalService.fetchCountryByA2(
 					companyId, "US");
-
-				if (country == null) {
-					return;
-				}
 
 				Assert.assertEquals(
 					57,

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
@@ -10,7 +10,6 @@ import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.portal.kernel.cache.MultiVMPool;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.CompanyTable;
 import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.Region;
@@ -55,10 +54,10 @@ public class CountryRegionUpgradeProcessTest {
 	public void testUpgradeProcessRegionCreation() throws Exception {
 		CompanyTestUtil.addCompany();
 
-		_companyLocalService.forEachCompany(
-			company -> {
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
 				Country country = _countryLocalService.fetchCountryByA2(
-					company.getCompanyId(), "US");
+					companyId, "US");
 
 				if (country == null) {
 					return;
@@ -70,10 +69,10 @@ public class CountryRegionUpgradeProcessTest {
 
 		_runUpgrade();
 
-		_companyLocalService.forEachCompany(
-			company -> {
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
 				Country country = _countryLocalService.fetchCountryByA2(
-					company.getCompanyId(), "US");
+					companyId, "US");
 
 				if (country == null) {
 					return;

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
@@ -53,6 +53,8 @@ public class CountryRegionUpgradeProcessTest {
 
 	@Test
 	public void testUpgradeProcessRegionCreation() throws Exception {
+		CompanyTestUtil.addCompany();
+
 		_companyLocalService.forEachCompany(
 			company -> {
 				Country country = _countryLocalService.fetchCountryByA2(
@@ -82,14 +84,6 @@ public class CountryRegionUpgradeProcessTest {
 					_regionLocalService.getRegionsCount(
 						country.getCountryId()));
 			});
-
-		Company company = CompanyTestUtil.addCompany();
-
-		Country country = _countryLocalService.getCountryByA2(
-			company.getCompanyId(), "US");
-
-		Assert.assertEquals(
-			57, _regionLocalService.getRegionsCount(country.getCountryId()));
 
 		_verifyCounters();
 		_verifyRegionLocalizationCompanyId();

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_1/test/CountryRegionUpgradeProcessTest.java
@@ -9,11 +9,8 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
-import com.liferay.portal.kernel.cache.MultiVMPool;
-import com.liferay.portal.kernel.model.CompanyTable;
 import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.Region;
-import com.liferay.portal.kernel.model.RegionLocalizationTable;
 import com.liferay.portal.kernel.model.RegionTable;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.CountryLocalService;
@@ -81,7 +78,7 @@ public class CountryRegionUpgradeProcessTest {
 						companyCountry.getCountryId()));
 			});
 
-		_verifyCounters();
+		_verifyCounter();
 	}
 
 	private void _runUpgrade() throws Exception {
@@ -91,7 +88,7 @@ public class CountryRegionUpgradeProcessTest {
 		upgradeProcess.upgrade();
 	}
 
-	private void _verifyCounters() {
+	private void _verifyCounter() {
 		List<Long> results = _regionLocalService.dslQuery(
 			DSLQueryFactoryUtil.select(
 				DSLFunctionFactoryUtil.max(


### PR DESCRIPTION
- LPD-17488 Fix counters before upgrade process
- LPD-17733 Fix companyId
- LPD-17488 PR changes required
- LPD-17488 Add module dependencies
- LPD-17488 Upgrade process test
- LPD-17488 Reuse method
- LPD-17488 SF & Use alphabetical order for parameters as in the rest of the methods
- LPD-17488 Only update the counters when needed
- LPD-17488 We are testing the upgrade
- LPD-17488 We do not need the Company object
- LPD-17488 Break the test if the testing data does not exist
- LPD-17488 Get the original count dinamically
- LPD-17488 Not needed
- LPD-17488 This check is not part of the upgrade logic. If needed, another non-upgrade test should be created
- LPD-17488 Just checking one
- LPD-17488 Disable dataGuard to avoid restoring issues and speeding up the process
